### PR TITLE
Fix store list not loading on employee register page

### DIFF
--- a/js/listarAtendentes.js
+++ b/js/listarAtendentes.js
@@ -23,7 +23,7 @@ export async function carregarAtendentes(lojaId = null) {
     }
 }
 
-function exibirListaAtendentes(atendentes) {
+async function exibirListaAtendentes(atendentes) {
     const lista = document.getElementById("listaAtendentes");
     lista.innerHTML = ""; // Limpar lista antes de renderizar
     


### PR DESCRIPTION
## Summary
- fix syntax in `listarAtendentes.js` so `exibirListaAtendentes` is declared as async

## Testing
- `node --check js/listarAtendentes.js`
- `node --check js/cadastro-funcionario.js`


------
https://chatgpt.com/codex/tasks/task_e_68851844b150832b958d910a4aeb6996