### PR TITLE
Add weekdays to registro calendar

### DIFF
--- a/js/ponto-registro.js
+++ b/js/ponto-registro.js
@@ -77,8 +77,11 @@ function criarCardDia(dataIso, registro) {
     }
 
     const [ano, mes, dia] = dataIso.split('-');
+    const dataObj = new Date(dataIso + 'T00:00:00');
+    const diaSemana = dataObj.toLocaleDateString('pt-BR', { weekday: 'long' });
+    const diaSemanaFormatado = diaSemana.charAt(0).toUpperCase() + diaSemana.slice(1);
     card.innerHTML = `
-        <label>${dia}/${mes}</label>
+        <label>${dia}/${mes} - ${diaSemanaFormatado}</label>
         <input type="time" class="entrada" value="${registro?.entrada || ''}">
         <input type="time" class="inicio-almoco" value="${registro?.inicioAlmoco || ''}">
         <input type="time" class="fim-almoco" value="${registro?.fimAlmoco || ''}">


### PR DESCRIPTION
## Summary
- show the day of the week when generating Registro Ponto calendar

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688c0eb79150832b941d79652bc7a994