### PR TITLE
feat: add new status fields to ponto registration

### DIFF
--- a/css/ponto.css
+++ b/css/ponto.css
@@ -91,22 +91,22 @@ h1 {
 
 .calendario-container {
   display: grid;
-.dia-card .feriado-label {
-    margin-top: 5px;
-    font-size: 14px;
-    color: #cc3333;
-}
-
-.info-feriado {
-    margin: 10px 0;
-    font-size: 14px;
-    color: #555;
-    text-align: center;
-}
-
   grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
   gap: 10px;
   margin-top: 20px;
+}
+
+.dia-card .status-label {
+  margin-top: 5px;
+  font-size: 14px;
+  color: #cc3333;
+}
+
+.info-feriado {
+  margin: 10px 0;
+  font-size: 14px;
+  color: #555;
+  text-align: center;
 }
 
 .dia-card {

--- a/html/ponto-registro.html
+++ b/html/ponto-registro.html
@@ -26,7 +26,7 @@
                 <option value="">Selecione</option>
             </select>
         </div>
-        <p class="info-feriado">Use o campo <strong>Feriado?</strong> para indicar se o dia &eacute; feriado.</p>
+        <p class="info-feriado">Use os campos <strong>Feriado?</strong>, <strong>Atestado?</strong>, <strong>Folga?</strong> e <strong>Descontar em Horas?</strong> para indicar o status do dia.</p>
         <div id="calendarioContainer" class="calendario-container"></div>
         <div class="save-button">
             <button id="salvarRegistros">Salvar</button>

--- a/js/ponto-registro.js
+++ b/js/ponto-registro.js
@@ -93,8 +93,23 @@ function criarCardDia(dataIso, registro) {
         <input type="time" class="inicio-almoco" value="${registro?.inicioAlmoco || ''}">
         <input type="time" class="fim-almoco" value="${registro?.fimAlmoco || ''}">
         <input type="time" class="saida" value="${registro?.saida || ''}">
-        <label class="feriado-label" title="Dia é feriado?">Feriado?</label>
+        <label class="status-label" title="Dia é feriado?">Feriado?</label>
         <select class="feriado">
+            <option value="NAO">Não</option>
+            <option value="SIM">Sim</option>
+        </select>
+        <label class="status-label" title="Dia possui atestado?">Atestado?</label>
+        <select class="atestado">
+            <option value="NAO">Não</option>
+            <option value="SIM">Sim</option>
+        </select>
+        <label class="status-label" title="Dia é folga?">Folga?</label>
+        <select class="folga">
+            <option value="NAO">Não</option>
+            <option value="SIM">Sim</option>
+        </select>
+        <label class="status-label" title="Descontar em horas?">Descontar em Horas?</label>
+        <select class="descontar-em-horas">
             <option value="NAO">Não</option>
             <option value="SIM">Sim</option>
         </select>
@@ -118,6 +133,15 @@ function criarCardDia(dataIso, registro) {
     feriadoSelect.addEventListener('change', e => {
         card.classList.toggle('feriado', e.target.value === 'SIM');
     });
+
+    const atestadoSelect = card.querySelector('.atestado');
+    atestadoSelect.value = registro?.atestado || 'NAO';
+
+    const folgaSelect = card.querySelector('.folga');
+    folgaSelect.value = registro?.folga || 'NAO';
+
+    const descontarSelect = card.querySelector('.descontar-em-horas');
+    descontarSelect.value = registro?.descontarEmHoras || 'NAO';
     return card;
 }
 
@@ -153,6 +177,9 @@ async function salvarPontos() {
             fimAlmoco: card.querySelector('.fim-almoco').value,
             saida: card.querySelector('.saida').value,
             feriado: card.querySelector('.feriado').value,
+            atestado: card.querySelector('.atestado').value,
+            folga: card.querySelector('.folga').value,
+            descontarEmHoras: card.querySelector('.descontar-em-horas').value,
             atendenteId: parseInt(atendenteSelect.value)
         };
         if (!payload.entrada || !payload.inicioAlmoco || !payload.fimAlmoco || !payload.saida) {
@@ -184,6 +211,9 @@ async function atualizarPonto(id, card) {
         fimAlmoco: card.querySelector('.fim-almoco').value,
         saida: card.querySelector('.saida').value,
         feriado: card.querySelector('.feriado').value,
+        atestado: card.querySelector('.atestado').value,
+        folga: card.querySelector('.folga').value,
+        descontarEmHoras: card.querySelector('.descontar-em-horas').value,
         atendenteId: parseInt(atendenteSelect.value)
     };
     try {


### PR DESCRIPTION
## Summary
- add atestado, folga and descontar em horas inputs on register ponto page
- send new status fields when saving or updating pontos
- style status labels for the new fields

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897825075e8832b86d82804dd9e0f29