### PR TITLE
Display separate overtime totals

### DIFF
--- a/html/horas-extras.html
+++ b/html/horas-extras.html
@@ -32,9 +32,9 @@
                 <tr>
                     <th>Atendente</th>
                     <th>Horas 50%</th>
-                    <th>Valor 50%</th>
+                    <th>Valor a Receber 50%</th>
                     <th>Horas 100%</th>
-                    <th>Valor 100%</th>
+                    <th>Valor a Receber 100%</th>
                 </tr>
             </thead>
             <tbody></tbody>

--- a/html/horas-extras.html
+++ b/html/horas-extras.html
@@ -31,9 +31,10 @@
             <thead>
                 <tr>
                     <th>Atendente</th>
-                    <th>Horas Extras</th>
-                    <th>Valor a Receber 50%</th>
-                    <th>Valor a Receber 100%</th>
+                    <th>Horas 50%</th>
+                    <th>Valor 50%</th>
+                    <th>Horas 100%</th>
+                    <th>Valor 100%</th>
                 </tr>
             </thead>
             <tbody></tbody>

--- a/js/horas-extras.js
+++ b/js/horas-extras.js
@@ -107,7 +107,7 @@ function renderizarTabela(dados) {
     if (!dados || dados.length === 0) {
         const tr = document.createElement('tr');
         const td = document.createElement('td');
-        td.colSpan = 4;
+        td.colSpan = 5;
         td.textContent = 'Nenhum resultado encontrado';
         tr.appendChild(td);
         tabelaBody.appendChild(tr);
@@ -119,21 +119,26 @@ function renderizarTabela(dados) {
         const nomeTd = document.createElement('td');
         nomeTd.textContent = item.nomeAtendente || item.nome || item.atendente || '';
 
-        const horasTd = document.createElement('td');
-        const duracao = item.totalHorasExtras || item.horasExtras || item.horas;
-        horasTd.textContent = formatarDuracao(duracao);
+        const horas50Td = document.createElement('td');
+        const duracao50 = item.totalHorasExtras50PorCento ?? item.totalHorasExtras ?? item.horasExtras50 ?? item.horas50;
+        horas50Td.textContent = formatarDuracao(duracao50);
 
         const valor50Td = document.createElement('td');
         const valor50 = item.valorAReceber50PorCento ?? item.valor50 ?? 0;
         valor50Td.textContent = formatarMoeda(valor50);
+
+        const horas100Td = document.createElement('td');
+        const duracao100 = item.totalHorasExtras100PorCento ?? item.horasExtras100 ?? item.horas100;
+        horas100Td.textContent = formatarDuracao(duracao100);
 
         const valor100Td = document.createElement('td');
         const valor100 = item.valorAReceber100PorCento ?? item.valor100 ?? 0;
         valor100Td.textContent = formatarMoeda(valor100);
 
         tr.appendChild(nomeTd);
-        tr.appendChild(horasTd);
+        tr.appendChild(horas50Td);
         tr.appendChild(valor50Td);
+        tr.appendChild(horas100Td);
         tr.appendChild(valor100Td);
 
         tabelaBody.appendChild(tr);


### PR DESCRIPTION
## Summary
- show dedicated columns for overtime at 50% and 100%
- adjust rendering logic for new API response fields

## Testing
- `npm test` *(fails: ENOENT, could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a4f93a34832bb07facdf0b3c164c