### PR TITLE
Allow XLS uploads in sales upload page

### DIFF
--- a/js/upload-vendas.js
+++ b/js/upload-vendas.js
@@ -39,7 +39,7 @@ function generateWeekFields() {
 
         const fileInput = document.createElement("input");
         fileInput.type = "file";
-        fileInput.accept=".xlsx";
+        fileInput.accept=".xlsx, .xls";
         weekDiv.appendChild(fileInput);
 
         const button = document.createElement("button");


### PR DESCRIPTION
## Summary
- Allow `.xls` files when uploading weekly sales spreadsheets

## Testing
- `npm test` (fails: ENOENT, missing package.json)

------
https://chatgpt.com/codex/tasks/task_e_68b78b919130832b86e22934574f05b2